### PR TITLE
Add GitHub Actions workflow for automatic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,13 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -21,23 +23,11 @@ jobs:
           go-version: '1.24'
           check-latest: true
 
-      - name: Build binaries
-        run: |
-          mkdir -p build
-          chmod +x ./build.sh
-          ./build.sh
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
         with:
-          name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
-          files: |
-            build/envgen-darwin-amd64
-            build/envgen-darwin-arm64
-            build/envgen-linux-amd64
-            build/envgen-linux-arm64
-            build/envgen-windows-amd64.exe
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          check-latest: true
+
+      - name: Build binaries
+        run: |
+          mkdir -p build
+          chmod +x ./build.sh
+          ./build.sh
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            build/envgen-darwin-amd64
+            build/envgen-darwin-arm64
+            build/envgen-linux-amd64
+            build/envgen-linux-arm64
+            build/envgen-windows-amd64.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch

--- a/main.go
+++ b/main.go
@@ -17,12 +17,15 @@ const (
 	defaultOutputFile   = ".env"
 )
 
+// version is set during build by GoReleaser
+var version = "dev"
+
 func main() {
 	app := &cli.App{
 		Name:        "envgen",
 		Usage:       "Generate .env files from AWS SSM Parameter Store",
 		Description: "A tool that generates .env files by retrieving values from AWS SSM Parameter Store based on a template file",
-		Version:     "1.0.0",
+		Version:     version,
 		Compiled:    time.Now(),
 		Authors: []*cli.Author{
 			{


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically creates a new release with built binaries when a new tag is pushed to the repository. The workflow uses the existing build.sh script to build binaries for multiple platforms.